### PR TITLE
Travis CI using hadoop 2.7.7, spark 2.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,9 @@ before_cache:
 # https://github.com/travis-ci/travis-ci/issues/1519.
 matrix:
   include:
-    # Scala 2.10.5 tests:
-    - jdk: openjdk7
-      scala: 2.10.5
-      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="2.0.0" SPARK_AVRO_VERSION="3.0.0" AWS_JAVA_SDK_VERSION="1.10.22"
-    # Scala 2.11 tests:
-    - jdk: openjdk7
+    - jdk: openjdk8
       scala: 2.11.7
-      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="2.0.0" SPARK_AVRO_VERSION="3.0.0" AWS_JAVA_SDK_VERSION="1.10.22"
-    # Test with an old version of the AWS Java SDK
-    - jdk: openjdk7
-      scala: 2.11.7
-      env: HADOOP_VERSION="2.2.0" SPARK_VERSION="2.0.0" SPARK_AVRO_VERSION="3.0.0" AWS_JAVA_SDK_VERSION="1.7.4"
+      env: HADOOP_VERSION="2.7.7" SPARK_VERSION="2.4.3" AWS_JAVA_SDK_VERSION="1.7.4"
 
 script:
   - ./dev/run-tests-travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ before_cache:
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
   - find $HOME/.sbt -name "*.lock" -delete
-# There's no nicer way to specify this matrix; see
-# https://github.com/travis-ci/travis-ci/issues/1519.
 matrix:
   include:
     - jdk: openjdk8

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Performant Redshift Data Source for Apache Spark - Community edition
 
+[![Build Status](https://travis-ci.org/spark-redshift-community/spark-redshift.svg?branch=master)](https://travis-ci.com/spark-redshift-community/spark-redshift)
+[![codecov.io](http://codecov.io/github/spark-redshift-community/spark-redshift/coverage.svg?branch=master)](http://codecov.io/github/spark-redshift-community/spark-redshift?branch=master)
 
 Welcome to the community edition of spark-redshift! 
  The community's feedback and contributions are vitally important. 

--- a/dev/run-tests-travis.sh
+++ b/dev/run-tests-travis.sh
@@ -10,7 +10,6 @@ sbt \
   -Daws.testVersion=$AWS_JAVA_SDK_VERSION \
   -Dhadoop.testVersion=$HADOOP_VERSION \
   -Dspark.testVersion=$SPARK_VERSION \
-  -DsparkAvro.testVersion=$SPARK_AVRO_VERSION \
   ++$TRAVIS_SCALA_VERSION \
   coverage test coverageReport
 
@@ -19,7 +18,6 @@ if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
     -Daws.testVersion=$AWS_JAVA_SDK_VERSION \
     -Dhadoop.testVersion=$HADOOP_VERSION \
     -Dspark.testVersion=$SPARK_VERSION \
-    -DsparkAvro.testVersion=$SPARK_AVRO_VERSION \
     ++$TRAVIS_SCALA_VERSION \
     coverage it:test coverageReport 2> /dev/null;
 fi

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,6 +16,4 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
-
 libraryDependencies += "org.apache.maven" % "maven-artifact" % "3.3.9"


### PR DESCRIPTION
Fixes #13 

- Set up Travis CI
- Test on hadoop 2.7.7 and spark 2.4.3
- Remove sbt assembly as it's not needed
- Adding icons for coverage and build status
- Coverage fails cause master coverage was never computed but we need this out to do that.

for review @dichiarafrancesco or @smoy 