### PR TITLE
Modernize datetime parsing - use DateTimeFormatter from Java 8

### DIFF
--- a/src/it/scala/io/github/spark_redshift_community/spark/redshift/RedshiftReadSuite.scala
+++ b/src/it/scala/io/github/spark_redshift_community/spark/redshift/RedshiftReadSuite.scala
@@ -215,6 +215,21 @@ class RedshiftReadSuite extends IntegrationSuiteBase {
     }
   }
 
+  test("test timestamptz parsing") {
+    withTempRedshiftTable("luca_test_timestamptz_spark_redshift") { tableName =>
+      conn.createStatement().executeUpdate(
+        s"CREATE TABLE $tableName (x timestamptz)"
+      )
+      conn.createStatement().executeUpdate(
+        s"INSERT INTO $tableName VALUES ('2015-07-03 00:00:00.000 -0300')"
+      )
+
+      checkAnswer(
+        read.option("dbtable", tableName).load(),
+        Seq(Row.apply("2015-07-03 03:00:00.0"))
+      )
+    }
+  }
 
   test("read special double values (regression test for #261)") {
     val tableName = s"roundtrip_special_double_values_$randomSuffix"

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Conversions.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Conversions.scala
@@ -77,7 +77,8 @@ private[redshift] object Conversions {
 
   /**
     * From the DateTimeFormatter docs (Java 8):
-    * "A formatter created from a pattern can be used as many times as necessary, it is immutable and is thread-safe."
+    * "A formatter created from a pattern can be used as many times as necessary,
+    * it is immutable and is thread-safe."
     */
   private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS][.SS][.S][ X]")
 

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Conversions.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Conversions.scala
@@ -80,7 +80,7 @@ private[redshift] object Conversions {
     * "A formatter created from a pattern can be used as many times as necessary,
     * it is immutable and is thread-safe."
     */
-  private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS][.SS][.S][ X]")
+  private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS][.SS][.S][X]")
 
   def parseRedshiftTimestamp(s: String): Timestamp = {
     val temporalAccessor = formatter.parse(s)

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
@@ -62,9 +62,10 @@ class ConversionsSuite extends FunSuite {
     val rowConverter = createRowConverter(
       StructType(Seq(StructField("timestampWithTimezone", TimestampType))))
 
-    val timestampWithTimezone = "2014-03-01 00:00:01.123+00"
+    // when converting to timestamp, we discard the TZ info.
+    val timestampWithTimezone = "2014-03-01 00:00:01.123-03"
     val expectedTimestampWithTimezoneMillis = TestUtils.toMillis(
-      2014, 2, 1, 0, 0, 1, 123)
+      2014, 1, 28, 19, 0, 1, 123)
 
     val convertedRow = rowConverter(Array(timestampWithTimezone))
     val expectedRow = Row(new Timestamp(expectedTimestampWithTimezoneMillis))

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
@@ -17,6 +17,7 @@
 package io.github.spark_redshift_community.spark.redshift
 
 import java.sql.Timestamp
+import java.time.{LocalDateTime, ZoneId, ZoneOffset, ZonedDateTime}
 import java.util.Locale
 
 import org.apache.spark.sql.Row
@@ -43,9 +44,9 @@ class ConversionsSuite extends FunSuite {
     // scalastyle:on
 
     val timestampWithMillis = "2014-03-01 00:00:01.123"
+    val expectedTimestampMillis = TestUtils.toMillis(2014, 2, 1, 0, 0, 1, 123)
 
     val expectedDateMillis = TestUtils.toMillis(2015, 6, 1, 0, 0, 0)
-    val expectedTimestampMillis = TestUtils.toMillis(2014, 2, 1, 0, 0, 1, 123)
 
     val convertedRow = convertRow(
       Array("1", "t", "2015-07-01", doubleMin, "1.0", "42",
@@ -64,8 +65,9 @@ class ConversionsSuite extends FunSuite {
 
     // when converting to timestamp, we discard the TZ info.
     val timestampWithTimezone = "2014-03-01 00:00:01.123-03"
+
     val expectedTimestampWithTimezoneMillis = TestUtils.toMillis(
-      2014, 1, 28, 19, 0, 1, 123)
+      2014, 2, 1, 0, 0, 1, 123, "-03")
 
     val convertedRow = rowConverter(Array(timestampWithTimezone))
     val expectedRow = Row(new Timestamp(expectedTimestampWithTimezoneMillis))

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
@@ -58,6 +58,20 @@ class ConversionsSuite extends FunSuite {
     assert(convertedRow == expectedRow)
   }
 
+  test("Regression test for parsing timestamptz (bug #25 in spark_redshift_community)") {
+    val rowConverter = createRowConverter(
+      StructType(Seq(StructField("timestampWithTimezone", TimestampType))))
+
+    val timestampWithTimezone = "2014-03-01 00:00:01.123 -0300"
+    val expectedTimestampWithTimezoneMillis = TestUtils.toMillis(
+      2014, 2, 1, 0, 0, 1, 123)
+
+    val convertedRow = rowConverter(Array(timestampWithTimezone))
+    val expectedRow = Row(new Timestamp(expectedTimestampWithTimezoneMillis))
+
+    assert(convertedRow == expectedRow)
+  }
+
   test("Row conversion handles null values") {
     val convertRow = createRowConverter(TestUtils.testSchema)
     val emptyRow = List.fill(TestUtils.testSchema.length)(null).toArray[String]

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
@@ -62,7 +62,7 @@ class ConversionsSuite extends FunSuite {
     val rowConverter = createRowConverter(
       StructType(Seq(StructField("timestampWithTimezone", TimestampType))))
 
-    val timestampWithTimezone = "2014-03-01 00:00:01.123 -0300"
+    val timestampWithTimezone = "2014-03-01 00:00:01.123+00"
     val expectedTimestampWithTimezoneMillis = TestUtils.toMillis(
       2014, 2, 1, 0, 0, 1, 123)
 

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/TestUtils.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/TestUtils.scala
@@ -17,7 +17,8 @@
 package io.github.spark_redshift_community.spark.redshift
 
 import java.sql.{Date, Timestamp}
-import java.util.{Calendar, Locale}
+import java.time.ZoneId
+import java.util.{Calendar, Locale, TimeZone}
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
@@ -84,10 +85,12 @@ object TestUtils {
       hour: Int,
       minutes: Int,
       seconds: Int,
-      millis: Int = 0): Long = {
+      millis: Int = 0,
+      timeZone: String = null): Long = {
     val calendar = Calendar.getInstance()
     calendar.set(year, zeroBasedMonth, date, hour, minutes, seconds)
     calendar.set(Calendar.MILLISECOND, millis)
+    if (timeZone != null) calendar.setTimeZone(TimeZone.getTimeZone(ZoneId.of(timeZone)))
     calendar.getTime.getTime
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.0.0-preview20190730"
+version in ThisBuild := "4.0.0-preview20190813"


### PR DESCRIPTION
Fixes #25 

DateTimeFormatter is the Java 8 better version of SimpleDateFormat. It allows optional parsing args and many nice things, like it's immutable and thread-safe.

For review @davidmarin @smoy @dichiarafrancesco 