### PR TITLE
Expected value in timestamptz test was wrong

### DIFF
--- a/src/it/scala/io/github/spark_redshift_community/spark/redshift/RedshiftReadSuite.scala
+++ b/src/it/scala/io/github/spark_redshift_community/spark/redshift/RedshiftReadSuite.scala
@@ -16,6 +16,8 @@
 
 package io.github.spark_redshift_community.spark.redshift
 
+import java.sql.Timestamp
+
 import org.apache.spark.sql.types.LongType
 import org.apache.spark.sql.{Row, execution}
 
@@ -226,7 +228,9 @@ class RedshiftReadSuite extends IntegrationSuiteBase {
 
       checkAnswer(
         read.option("dbtable", tableName).load(),
-        Seq(Row.apply("2015-07-03 03:00:00.0"))
+        Seq(Row.apply(
+          new Timestamp(TestUtils.toMillis(
+      2015, 6, 3, 0, 0, 0, 0, "-03"))))
       )
     }
   }

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
@@ -17,7 +17,6 @@
 package io.github.spark_redshift_community.spark.redshift
 
 import java.sql.Timestamp
-import java.time.{LocalDateTime, ZoneId, ZoneOffset, ZonedDateTime}
 import java.util.Locale
 
 import org.apache.spark.sql.Row


### PR DESCRIPTION
Integration tests are failing because they depend on the timezone of the test machine.

I'm now creating the test expected value with timezone information so this should run properly anywhere.

For review @smoy or @davidmarin 