### PR TITLE
Stable 4.0.0 release to publish to maven central

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,18 @@
 # spark-redshift Changelog
 
+## 4.0.0
+
+This major release makes spark-redshift compatible with spark 2.4. This was tested in production.
+
+While upgrading the package we droped some features due to time constraints.
+
+- Support for hadoop 1.x has been dropped.
+- STS and IAM authentication support has been dropped.
+- postgresql driver tests are inactive.
+- SaveMode tests (or functionality?) are broken. This is a bit scary but I'm not sure we use the functionality
+ and fixing them didn't make it in this version (spark-snowflake removed them too).
+- S3Native has been deprecated. We created an InMemoryS3AFileSystem to test S3A.
+
 ## 4.0.0-SNAPSHOT
 - SNAPSHOT version to test publishing to Maven Central.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Our intent is to do the best job possible supporting the minimal set of features
 
 This is currently not tested on EMR. Some tests have been temporarily disabled and some features removed.
 
+## How to help
+
+Community's contributions are very welcome! Feel free to:
+
+- Open an issue on github
+- Open a PR on github. Make sure tests pass.
+- Contact the developers in the 'developers' section in the build.sbt file.
+
 # Original DataBricks Readme
 
 ## Note

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.0.0-SNAPSHOT"
+version in ThisBuild := "4.0.0"


### PR DESCRIPTION
I'm publishing a stable release to publish this to Maven Central.

There has been no progress on the dropped features (except better testing) but I think it's worth to put something out to let people to use this.

@davidmarin  for review