### PR TITLE
Correct wrong warning when tmp bucket lifecycle policy has no prefix

### DIFF
--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Utils.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Utils.scala
@@ -153,7 +153,7 @@ private[redshift] object Utils {
       true
     } catch {
       case NonFatal(e) =>
-        log.warn("An error occurred while trying to read the S3 bucket lifecycle configuration", e)
+        log.warn("An error occurred while trying to read the S3 bucket lifecycle configuration")
         false
     }
   }

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/UtilsSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/UtilsSuite.scala
@@ -98,7 +98,7 @@ class UtilsSuite extends FunSuite with Matchers {
 
     when(mockS3Client.getBucketLifecycleConfiguration(anyString())).thenReturn(
       new BucketLifecycleConfiguration().withRules(
-        new Rule().withPrefix("/path/")withStatus(BucketLifecycleConfiguration.ENABLED)
+        new Rule().withPrefix("/path/").withStatus(BucketLifecycleConfiguration.ENABLED)
       ))
     assert(Utils.checkThatBucketHasObjectLifecycleConfiguration(
       "s3a://bucket/path/to/temp/dir", mockS3Client) === true)
@@ -110,7 +110,7 @@ class UtilsSuite extends FunSuite with Matchers {
 
     when(mockS3Client.getBucketLifecycleConfiguration(anyString())).thenReturn(
       new BucketLifecycleConfiguration().withRules(
-        new Rule()withStatus(BucketLifecycleConfiguration.ENABLED)
+        new Rule().withStatus(BucketLifecycleConfiguration.ENABLED)
       ))
     assert(Utils.checkThatBucketHasObjectLifecycleConfiguration(
       "s3a://bucket/path/to/temp/dir", mockS3Client) === true)


### PR DESCRIPTION
This PR just avoid having a warning with a stacktrace when the used tmp bucket is configured with a lifecycle without prefix.