### PR TITLE
removed rule.getPrefix method call since this now returns null

### DIFF
--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Utils.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Utils.scala
@@ -137,7 +137,7 @@ private[redshift] object Utils {
           // Note: this only checks that there is an active rule which matches the temp directory;
           // it does not actually check that the rule will delete the files. This check is still
           // better than nothing, though, and we can always improve it later.
-          rule.getStatus == BucketLifecycleConfiguration.ENABLED && key.startsWith(rule.getPrefix)
+          rule.getStatus == BucketLifecycleConfiguration.ENABLED
         }
       }
       if (!hasMatchingBucketLifecycleRule) {


### PR DESCRIPTION
Removed this call since the call is simply checking that the lifecycle has been enabled.  It was incorrectly giving a warning and a stack trace.