### PR TITLE
Handle microseconds from redshift

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # spark-redshift Changelog
 
+## 4.0.1
+
+- Fix bug when parsing microseconds from Redshift
+
 ## 4.0.0
 
 This major release makes spark-redshift compatible with spark 2.4. This was tested in production.

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Conversions.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Conversions.scala
@@ -37,7 +37,8 @@ private[redshift] object Conversions {
     * "A formatter created from a pattern can be used as many times as necessary,
     * it is immutable and is thread-safe."
     */
-  private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSS][.SS][.S][X]")
+  private val formatter = DateTimeFormatter.ofPattern(
+    "yyyy-MM-dd HH:mm:ss[.SSSSSS][.SSS][.SS][.S][X]")
 
   /**
    * Parse a boolean using Redshift's UNLOAD bool syntax

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Conversions.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Conversions.scala
@@ -38,7 +38,7 @@ private[redshift] object Conversions {
     * it is immutable and is thread-safe."
     */
   private val formatter = DateTimeFormatter.ofPattern(
-    "yyyy-MM-dd HH:mm:ss[.SSSSSS][.SSS][.SS][.S][X]")
+    "yyyy-MM-dd HH:mm:ss[.SSSSSS][.SSSSS][.SSSS][.SSS][.SS][.S][X]")
 
   /**
    * Parse a boolean using Redshift's UNLOAD bool syntax

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
@@ -96,6 +96,10 @@ class ConversionsSuite extends FunSuite {
     Seq(
       "2014-03-01 00:00:01.123456" ->
         TestUtils.toNanosTimestamp(2014, 2, 1, 0, 0, 1, nanos = 123456000),
+      "2014-03-01 00:00:01.12345" ->
+        TestUtils.toNanosTimestamp(2014, 2, 1, 0, 0, 1, nanos = 123450000),
+      "2014-03-01 00:00:01.1234" ->
+        TestUtils.toNanosTimestamp(2014, 2, 1, 0, 0, 1, nanos = 123400000),
       "2014-03-01 00:00:01" ->
         TestUtils.toTimestamp(2014, 2, 1, 0, 0, 0, millis = 1000),
       "2014-03-01 00:00:01.000" ->

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/ConversionsSuite.scala
@@ -94,19 +94,29 @@ class ConversionsSuite extends FunSuite {
     val schema = StructType(Seq(StructField("a", TimestampType)))
     val convertRow = createRowConverter(schema)
     Seq(
-      "2014-03-01 00:00:01" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 1000),
-      "2014-03-01 00:00:01.000" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 1000),
-      "2014-03-01 00:00:00.1" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 100),
-      "2014-03-01 00:00:00.10" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 100),
-      "2014-03-01 00:00:00.100" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 100),
-      "2014-03-01 00:00:00.01" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 10),
-      "2014-03-01 00:00:00.010" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 10),
-      "2014-03-01 00:00:00.001" -> TestUtils.toMillis(2014, 2, 1, 0, 0, 0, millis = 1)
+      "2014-03-01 00:00:01.123456" ->
+        TestUtils.toNanosTimestamp(2014, 2, 1, 0, 0, 1, nanos = 123456000),
+      "2014-03-01 00:00:01" ->
+        TestUtils.toTimestamp(2014, 2, 1, 0, 0, 0, millis = 1000),
+      "2014-03-01 00:00:01.000" ->
+        TestUtils.toTimestamp(2014, 2, 1, 0, 0, 0, millis = 1000),
+      "2014-03-01 00:00:00.1" ->
+        TestUtils.toTimestamp(2014, 2, 1, 0, 0, 0, millis = 100),
+      "2014-03-01 00:00:00.10" ->
+        TestUtils.toTimestamp(2014, 2, 1, 0, 0, 0, millis = 100),
+      "2014-03-01 00:00:00.100" ->
+        TestUtils.toTimestamp(2014, 2, 1, 0, 0, 0, millis = 100),
+      "2014-03-01 00:00:00.01" ->
+        TestUtils.toTimestamp(2014, 2, 1, 0, 0, 0, millis = 10),
+      "2014-03-01 00:00:00.010" ->
+        TestUtils.toTimestamp(2014, 2, 1, 0, 0, 0, millis = 10),
+      "2014-03-01 00:00:00.001" ->
+        TestUtils.toTimestamp(2014, 2, 1, 0, 0, 0, millis = 1)
     ).foreach { case (timestampString, expectedTime) =>
       withClue(s"timestamp string is '$timestampString'") {
         val convertedRow = convertRow(Array(timestampString))
         val convertedTimestamp = convertedRow.get(0).asInstanceOf[Timestamp]
-        assert(convertedTimestamp === new Timestamp(expectedTime))
+        assert(convertedTimestamp === expectedTime)
       }
     }
   }

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/TestUtils.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/TestUtils.scala
@@ -94,6 +94,29 @@ object TestUtils {
     calendar.getTime.getTime
   }
 
+  def toNanosTimestamp(
+    year: Int,
+    zeroBasedMonth: Int,
+    date: Int,
+    hour: Int,
+    minutes: Int,
+    seconds: Int,
+    nanos: Int
+                               ): Timestamp = {
+    val ts = new Timestamp(
+      toMillis(
+        year,
+        zeroBasedMonth,
+        date,
+        hour,
+        minutes,
+        seconds
+      )
+    )
+    ts.setNanos(nanos)
+    ts
+  }
+
   /**
    * Convert date components to a SQL Timestamp
    */

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.0.0"
+version in ThisBuild := "4.0.1"


### PR DESCRIPTION
Handling microseconds (6 digits after the comma).
Fixes #35 and #48 