### PR TITLE
Issue #87: Creating a serializer per row has a really low performance.

### DIFF
--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Conversions.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Conversions.scala
@@ -135,7 +135,7 @@ private[redshift] object Conversions {
     // As a performance optimization, re-use the same mutable row / array:
     val converted: Array[Any] = Array.fill(schema.length)(null)
     val externalRow = new GenericRow(converted)
-    val encoder = RowEncoder(schema)
+    val toRow = RowEncoder(schema).createSerializer()
     (inputRow: Array[String]) => {
       var i = 0
       while (i < schema.length) {
@@ -152,7 +152,7 @@ private[redshift] object Conversions {
         }
         i += 1
       }
-      encoder.createSerializer().apply(externalRow)
+      toRow.apply(externalRow)
     }
   }
 }


### PR DESCRIPTION
Instead of creating a new serializer per row, it is better to create only one per schema.

It is thread-safe because this object does not escape from the thread associated with some Spark task.