### PR TITLE
Remove reliance on sbt-spark-package

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,10 +2,6 @@ addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.5")
 
-resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
-
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.2")
-
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/FilterPushdownSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/FilterPushdownSuite.scala
@@ -71,7 +71,7 @@ class FilterPushdownSuite extends FunSuite {
         |AND "test_int" <= 43
         |AND "test_int" IS NOT NULL
         |AND "test_int" IS NULL
-      """.stripMargin.lines.mkString(" ").trim
+      """.stripMargin.lines.toArray.mkString(" ").trim
     // scalastyle:on
     assert(whereClause === expectedWhereClause)
   }

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/RedshiftSourceSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/RedshiftSourceSuite.scala
@@ -190,7 +190,7 @@ class RedshiftSourceSuite
         |  \(select testbyte, testbool
         |    from test_table
         |    where teststring = \\'\\\\\\\\Unicode\\'\\'s樂趣\\'\) '\)
-      """.stripMargin.lines.map(_.trim).mkString(" ").trim.r
+      """.stripMargin.lines.map(_.trim).toArray.mkString(" ").trim.r
     val query =
       """select testbyte, testbool from test_table where teststring = '\\Unicode''s樂趣'"""
     unloadedData = "1|t"


### PR DESCRIPTION
The `sbt-spark-package` plugin was hosted on bintray, which no longer hosts libraries.  Databricks seems to have abandoned sbt-spark-package, so the jar isn't hosted anywhere and our builds crash.

This PR removes the plugin dependency, which required changing some of the build process.

I had a compile error on the two test files, not sure why that didn't show anytime before.