### PR TITLE
Update Spark version and aws java sdk version for consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   include:
     - jdk: openjdk8
       scala: 2.12.11
-      env: HADOOP_VERSION="3.2.1" SPARK_VERSION="3.0.1" AWS_JAVA_SDK_VERSION="1.11.375"
+      env: HADOOP_VERSION="3.2.1" SPARK_VERSION="3.0.2" AWS_JAVA_SDK_VERSION="1.11.1033"
 
 script:
   - ./dev/run-tests-travis.sh

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # spark-redshift Changelog
 
+## 5.0.4 (2021-07-08)
+
+- Upgrade spark version to 3.0.2 and to latest test aws java sdk version to latest
+
 ## 5.0.3 (2021-05-10)
 
 - Remove sbt-spark-package plugin dependency (#90)

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 import sbtrelease.ReleasePlugin.autoImport._
 import scoverage.ScoverageKeys
 
-val sparkVersion = "3.0.1"
+val sparkVersion = "3.0.2"
 
 // Define a custom test configuration so that unit test helper classes can be re-used under
 // the integration tests configuration; see http://stackoverflow.com/a/20635808.
@@ -30,7 +30,7 @@ lazy val IntegrationTest = config("it") extend Test
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val testHadoopVersion = sys.props.get("hadoop.testVersion").getOrElse("3.2.1")
 // DON't UPGRADE AWS-SDK-JAVA if not compatible with hadoop version
-val testAWSJavaSDKVersion = sys.props.get("aws.testVersion").getOrElse("1.11.375")
+val testAWSJavaSDKVersion = sys.props.get("aws.testVersion").getOrElse("1.11.1033")
 
 
 lazy val root = Project("spark-redshift", file("."))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.3"
+version in ThisBuild := "5.0.4"


### PR DESCRIPTION
Upgrading spark version to 3.0.2 and aws java sdk version to 1.11.1033 for consistency purposes.
Don't expect any issues with these changes so far.
### 
Testing
make test itest