### PR TITLE
fix: log4j-api not compatibility with spark 3.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val root = Project("spark-redshift", file("."))
     scalacOptions ++= Seq("-target:jvm-1.8"),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     libraryDependencies ++= Seq(
-      "org.slf4j" % "slf4j-api" % "1.7.5",
+      "org.slf4j" % "slf4j-api" % "1.7.32",
       "com.eclipsesource.minimal-json" % "minimal-json" % "0.9.4",
 
       // A Redshift-compatible JDBC driver must be present on the classpath for spark-redshift to work.


### PR DESCRIPTION
In spark-streaming_2.12 % 3.2.0 using log4j 1.7 as dependencies
slf4j-api % 1.7.5 not compatibility causing `Exception in thread "Executor task launch worker-0" java.lang.NoSuchMethodError: 'java.lang.String org.slf4j.helpers.Util.safeGetSystemProperty(java.lang.String)'`
upgrade slf4j-api to 1.7.32 can solve problem