### PR TITLE
Support SUPER columns

### DIFF
--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
@@ -308,6 +308,7 @@ private[redshift] class JDBCWrapper {
       case java.sql.Types.NCHAR         => StringType
       case java.sql.Types.NVARCHAR      => StringType
       case java.sql.Types.VARCHAR       => StringType
+      case java.sql.Types.LONGVARCHAR   => StringType
 
       // Datetime Types
       case java.sql.Types.DATE          => DateType


### PR DESCRIPTION
# Why
Reading from tables with columns of SUPER type results in the error "Unsupported type -1". This is because the SQL type for SUPER columns presents as [`LONGVARCHAR`](https://docs.oracle.com/javase/8/docs/api/java/sql/Types.html#LONGNVARCHAR) and there is no mapping for `LONGVARCHAR` to a catalyst type.

Using [`JSON_SERIALIZE`](https://docs.aws.amazon.com/redshift/latest/dg/JSON_SERIALIZE.html) to cast the SUPER column into VARCHAR in a query does not always work as the size limit for SUPER is much larger than the size limit for VARCHAR and so `JSON_SERIALIZE` returns an error for large SUPER values.

# How
Add catalyst type mapping for LONGVARCHAR.

# Testing
I've manually tested this for my use case and I can successfully read SUPER data.