### PR TITLE
Bump version to 5.1.0 to support Spark 3.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 # spark-redshift Changelog
 
+## 5.1.0 (2022-09-22)
+
+- Make manifest file path use s3a/n scheme
+- Add catalyst type mapping for LONGVARCHAR
+- Upgrade to Spark 3.2
+- Fix log4j-apt compatability with Spark 3.2
+
 ## 5.0.5 (2021-11-09)
 
 - Avoid warning when tmp bucket is configured with a lifecycle without prefix.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.0.5"
+version in ThisBuild := "5.1.0"


### PR DESCRIPTION
Bump version for the changes below:
- Make manifest file path use s3a/n scheme
- Add catalyst type mapping for LONGVARCHAR
- Upgrade to Spark 3.2
- Fix log4j-apt compatability with Spark 3.2