### PR TITLE
Fix Thread Safe Issue in MakeTempPath function

### DIFF
--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Utils.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Utils.scala
@@ -112,8 +112,9 @@ private[redshift] object Utils {
    * Creates a randomly named temp directory path for intermediate data
    */
   def makeTempPath(tempRoot: String): String = {
-    lastTempPathGenerated = Utils.joinUrls(tempRoot, UUID.randomUUID().toString)
-    lastTempPathGenerated
+    val _lastTempPathGenerated = Utils.joinUrls(tempRoot, UUID.randomUUID().toString)
+    lastTempPathGenerated = _lastTempPathGenerated
+    _lastTempPathGenerated
   }
 
   /**


### PR DESCRIPTION
This commit is to fix #121
Return the generated temp path directly instead via the object level variable