### PR TITLE
Update README about sbt usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ aws_variables.env
 derby.log
 metastore_db/
 lib_managed/
+.vscode/
+.metals/
+.bloop/
+venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+repos:
 - repo: local
   hooks:
     - id: sbt-compile-package

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -5,3 +5,4 @@
 * JDK 11 (since sbt currently supports to JDK 11)
 * sbt script version: 1.9.4
 * Python 3 (to use pre-commit) 
+* pre-commit 3.4.0

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -1,0 +1,7 @@
+# Developer notes to iterate on the code
+
+## Prerequisite
+
+* JDK 11 (since sbt currently supports to JDK 11)
+* sbt script version: 1.9.4
+* Python 3 (to use pre-commit) 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Community's contributions are very welcome! Feel free to:
 * Open an issue on github.
 * Open a PR on github. To ensure a smooth code review process, please follow these steps:
   * Install the project pre-commit hooks: `pre-commit install`
-  * Run unit tests: `./build/sbt test` 
+  * Run unit tests: `sbt test` 
   * [Install integration test data](#install-integration-test-data)
   * Run integration tests:
     * Export the following environment variables with your values:
@@ -58,7 +58,7 @@ Community's contributions are very welcome! Feel free to:
       export AWS_S3_SCRATCH_SPACE=<your AWS_S3_SCRATCH_SPACE>
       export AWS_S3_SCRATCH_SPACE_REGION=<AWS region of AWS_S3_SCRATCH_SPACE>
       ```
-     * run `./build/sbt it:test`
+     * run `sbt it:test`
    * Ensure commit messages are concise and descriptive.
    * Get a team member to review your code on github (if possible). This speeds up the PR approval for the admins.
 


### PR DESCRIPTION
I am trying to run ./build/sbt test but that doesn't seem working 

```
(venv) smoy@smoy-mba spark-redshift % ./build/sbt test
Using /Users/smoy/.sdkman/candidates/java/current as default JAVA_HOME.
Note, this will be overridden by -java-home if it is set.
Attempting to fetch sbt
Our attempt to download sbt locally to build/sbt-launch-0.13.18.jar failed. Please install sbt manually from http://www.scala-sbt.org/
```

When I install sbt, I can just run `sbt test` in the top level directory. 

I notice pre-commit config also simply run sbt instead of ./build/sbt, I suggest we update the sbt usage.