### PR TITLE
Log an info message about unloading data to S3

### DIFF
--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
@@ -352,6 +352,7 @@ private[redshift] class RedshiftWriter(
       }
     )
 
+    log.info("Unloading data to S3: {}", tempDir)
     val writer = sqlContext.createDataFrame(convertedRows, convertedSchema).write
     (tempFormat match {
       case "AVRO" =>

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
@@ -352,7 +352,7 @@ private[redshift] class RedshiftWriter(
       }
     )
 
-    log.info("Unloading data to S3: {}", tempDir)
+    log.info("Unloading data to S3")
     val writer = sqlContext.createDataFrame(convertedRows, convertedSchema).write
     (tempFormat match {
       case "AVRO" =>


### PR DESCRIPTION
In order to better understand how much time is spent on unloading data versus copying it to Redshift a log message marking the start of the former would be helpful. There's already a marker for the COPY command.