### PR TITLE
Maintenance Improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,7 @@ repos:
       language: system
       types: [file]
       pass_filenames: false
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks: 
+    - id: check-yaml

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,13 @@
 
 # spark-redshift Changelog
 
+## 6.2.0 (2024-01-12)
+- Validates support for Spark 3.3.4 and Spark 3.4.2
+- Upgrades Redshift JDBC driver to version 2.1.0.24
+- Fixes issue where CSV writes would trim leading and trailing whitespace on column values.
+- Improves logging during Redshift writes to differentiate time spent writing to S3 versus COPYing into Redshift (#148)
+- Supports pre-GA AWS regions.
+
 ## 6.1.0 (2023-10-06)
 
 - Support Spark 3.4.1 and 3.5.0

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You may use this library in your applications with the following dependency info
     spark-submit \
       --deploy-mode cluster \
       --master yarn \
-      --packages com.amazon.redshift:redshift-jdbc42:2.1.0.18,org.apache.spark:spark-avro_2.12:3.5.0,io.github.spark-redshift-community:spark-redshift_2.12:6.1.0-spark_3.5 \
+      --packages com.amazon.redshift:redshift-jdbc42:2.1.0.24,org.apache.spark:spark-avro_2.12:3.5.0,io.github.spark-redshift-community:spark-redshift_2.12:6.1.0-spark_3.5 \
       my_script.py
     ```
 
@@ -125,7 +125,7 @@ You may use this library in your applications with the following dependency info
     ```
 
 
-You will also need to provide a JDBC driver that is compatible with Redshift. Amazon recommends that you use [the official Amazon Redshift JDBC driver](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42/2.1.0.18), which is available on Maven Central. Additionally, is hosted in S3 and can be found in the [official AWS documentation for the Redshift JDBC Driver](https://docs.aws.amazon.com/redshift/latest/mgmt/jdbc20-install.html).
+You will also need to provide a JDBC driver that is compatible with Redshift. Amazon recommends that you use [the official Amazon Redshift JDBC driver](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42/2.1.0.24), which is available on Maven Central. Additionally, is hosted in S3 and can be found in the [official AWS documentation for the Redshift JDBC Driver](https://docs.aws.amazon.com/redshift/latest/mgmt/jdbc20-install.html).
 
 **Note on Hadoop versions**: This library depends on [`spark-avro`](https://github.com/databricks/spark-avro), which should automatically be downloaded because it is declared as a dependency. However, you may need to provide the corresponding `avro-mapred` dependency which matches your Hadoop distribution. In most deployments, however, this dependency will be automatically provided by your cluster's Spark assemblies and no additional action will be required.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You may use this library in your applications with the following dependency info
     spark-submit \
       --deploy-mode cluster \
       --master yarn \
-      --packages com.amazon.redshift:redshift-jdbc42:2.1.0.24,org.apache.spark:spark-avro_2.12:3.5.0,io.github.spark-redshift-community:spark-redshift_2.12:6.1.0-spark_3.5 \
+      --packages com.amazon.redshift:redshift-jdbc42:2.1.0.24,org.apache.spark:spark-avro_2.12:3.5.0,io.github.spark-redshift-community:spark-redshift_2.12:6.2.0-spark_3.5 \
       my_script.py
     ```
 
@@ -114,14 +114,14 @@ You may use this library in your applications with the following dependency info
     <dependency>
         <groupId>io.github.spark-redshift-community</groupId>
         <artifactId>spark-redshift_2.12</artifactId>
-        <version>6.1.0-spark_3.5</version>
+        <version>6.2.0-spark_3.5</version>
     </dependency>
     ```
 
 - **In SBT**:
 
     ```SBT
-    libraryDependencies += "io.github.spark-redshift-community" %% "spark-redshift_2.12" % "6.1.0-spark_3.5"
+    libraryDependencies += "io.github.spark-redshift-community" %% "spark-redshift_2.12" % "6.2.0-spark_3.5"
     ```
 
 
@@ -827,7 +827,7 @@ for more information.</p>
     <td>""</td>
     <td>
         An identifier to include in the query group set when running queries with the connector. Should be 100 or fewer characters and all characters must be valid unicodeIdentifierParts. Characters in excess of 100 will be trimmed.
-        When running a query with the connector a json formatted string will be set as the query group (for example `{"spark-redshift-connector":{"svc":"","ver":"6.1.0-spark_3.5","op":"Read","lbl":"","tid":""}}`). 
+        When running a query with the connector a json formatted string will be set as the query group (for example `{"spark-redshift-connector":{"svc":"","ver":"6.2.0-spark_3.5","op":"Read","lbl":"","tid":""}}`). 
         This option will be substituted for the value of the `lbl` key.
     </td>
 <tr>
@@ -936,7 +936,7 @@ SET spark.datasource.redshift.community.autopushdown.lazyMode=false
 ### trace_id
 A new tracing identifier field that is added to the existing `label` parameter. When set, the provided string value will be used as part of label. Otherwise, it will default to the Spark application identifier. For example:
 
-`{"spark-redshift-connector":{"svc":"","ver":"6.1.0-spark_3.5","op":"Read","lbl":"","tid":"..."}}`)
+`{"spark-redshift-connector":{"svc":"","ver":"6.2.0-spark_3.5","op":"Read","lbl":"","tid":"..."}}`)
 
 To set the value, run the following command:
 ```sparksql

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ val internalReleaseRepoPass = sys.props.get("ci.internalTeamMvnPassword").getOrE
 val releaseSparkVersion = testSparkVersion.substring(0, testSparkVersion.lastIndexOf("."))
 
 def incompatibleSparkVersions(): FileFilter = {
-  val versionArray = testSparkVersion.split("""\.""").map(Integer.parseInt)
+  val versionArray = releaseSparkVersion.split("""\.""").map(Integer.parseInt)
   val major = versionArray(0)
   val minor = versionArray(1)
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ val isCI = "true" equalsIgnoreCase System.getProperty("config.CI")
 lazy val IntegrationTest = config("it") extend Test
 val testSparkVersion = sys.props.get("spark.testVersion").getOrElse(sparkVersion)
 val testHadoopVersion = sys.props.get("hadoop.testVersion").getOrElse("3.3.3")
-val testJDBCVersion = sys.props.get("jdbc.testVersion").getOrElse("2.1.0.18")
+val testJDBCVersion = sys.props.get("jdbc.testVersion").getOrElse("2.1.0.24")
 // DON't UPGRADE AWS-SDK-JAVA if not compatible with hadoop version
 val testAWSJavaSDKVersion = sys.props.get("aws.testVersion").getOrElse("1.11.1033")
 // access tokens for aws/shared and our own internal CodeArtifacts repo

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Parameters.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Parameters.scala
@@ -34,6 +34,7 @@ private[redshift] object Parameters {
   val PARAM_COPY_RETRY_COUNT: String = "copyretrycount"
   val PARAM_COPY_DELAY: String = "copydelay"
   val PARAM_LEGACY_JDBC_REAL_TYPE_MAPPING: String = "legacy_jdbc_real_type_mapping"
+  val PARAM_LEGACY_TRIM_CSV_WRITES: String = "legacy_trim_csv_writes"
   val PARAM_OVERRIDE_NULLABLE: String = "overridenullable"
   val PARAM_TEMPDIR_REGION: String = "tempdir_region"
   val PARAM_SECRET_ID: String = "secret.id"
@@ -65,6 +66,7 @@ private[redshift] object Parameters {
     PARAM_COPY_RETRY_COUNT -> "2",
     PARAM_COPY_DELAY -> "0",
     PARAM_LEGACY_JDBC_REAL_TYPE_MAPPING -> "false",
+    PARAM_LEGACY_TRIM_CSV_WRITES -> "false",
     PARAM_TEMPDIR_REGION -> "",
     PARAM_USER_QUERY_GROUP_LABEL -> ""
   )
@@ -409,6 +411,13 @@ private[redshift] object Parameters {
      */
     def legacyJdbcRealTypeMapping: Boolean =
       parameters(PARAM_LEGACY_JDBC_REAL_TYPE_MAPPING).toBoolean
+
+    /**
+     * Trims leading and trailing whitespace when using CSV-based formats (CSV and CSV GZIP) for
+     * tempformat during writes. Added for backwards support with legacy applications.
+     */
+    def legacyTrimCSVWrites: Boolean =
+      parameters(PARAM_LEGACY_TRIM_CSV_WRITES).toBoolean
 
     /**
      * Turns empty strings into nulls

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Parameters.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Parameters.scala
@@ -171,7 +171,7 @@ private[redshift] object Parameters {
      */
     def tempDirRegion: Option[String] = {
       val regionName = parameters.getOrElse(PARAM_TEMPDIR_REGION, "")
-      if (regionName.isEmpty) None else Some(Regions.fromName(regionName).getName)
+      if (regionName.isEmpty) None else Some(regionName)
     }
 
     /**

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftWriter.scala
@@ -243,7 +243,8 @@ private[redshift] class RedshiftWriter(
       data: DataFrame,
       tempDir: String,
       tempFormat: String,
-      nullString: String): Option[String] = {
+      nullString: String,
+      trimCSV: Boolean): Option[String] = {
     // spark-avro does not support Date types. In addition, it converts Timestamps into longs
     // (milliseconds since the Unix epoch). Redshift is capable of loading timestamps in
     // 'epochmillisecs' format but there's no equivalent format for dates. To work around this, we
@@ -361,10 +362,14 @@ private[redshift] class RedshiftWriter(
         writer.format("csv")
           .option("escape", "\"")
           .option("nullValue", nullString)
+          .option("ignoreLeadingWhiteSpace", trimCSV)
+          .option("ignoreTrailingWhiteSpace", trimCSV)
       case "CSV GZIP" =>
         writer.format("csv")
           .option("escape", "\"")
           .option("nullValue", nullString)
+          .option("ignoreLeadingWhiteSpace", trimCSV)
+          .option("ignoreTrailingWhiteSpace", trimCSV)
           .option("compression", "gzip")
       case "PARQUET" =>
         writer.format("parquet")
@@ -476,7 +481,8 @@ private[redshift] class RedshiftWriter(
       data,
       tempDir = params.createPerQueryTempDir(),
       tempFormat = params.tempFormat,
-      nullString = params.nullString)
+      nullString = params.nullString,
+      trimCSV = params.legacyTrimCSVWrites)
 
     // Uncertain if this is necessary as s3 is now strongly consistent
     // https://aws.amazon.com/s3/consistency/

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Utils.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Utils.scala
@@ -287,9 +287,9 @@ private[redshift] object Utils {
     }
   }
 
-  def getDefaultTempDirRegion(tempDirRegion: Option[String]): Regions = {
+  def getDefaultTempDirRegion(tempDirRegion: Option[String]): String = {
     // If the user provided a region, use it above everything else.
-    if (tempDirRegion.isDefined) return Regions.fromName(tempDirRegion.get)
+    if (tempDirRegion.isDefined) return tempDirRegion.get
 
     // Either the user didn't provide a region or its malformed. Try to use the
     // connector's region as the tempdir region since they are usually collocated.
@@ -309,7 +309,7 @@ private[redshift] object Utils {
     }
 
     // If all else fails, pick a default region.
-    if (currRegion != null) Regions.fromName(currRegion.getName()) else Regions.US_EAST_1
+    if (currRegion != null) currRegion.getName else Regions.US_EAST_1.getName
   }
 
   def s3ClientBuilder: (AWSCredentialsProvider, MergedParameters) => AmazonS3 =

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Utils.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Utils.scala
@@ -331,10 +331,12 @@ private[redshift] object Utils {
     if (params.legacyJdbcRealTypeMapping) {
       metricLogger.info(s"${Parameters.PARAM_LEGACY_JDBC_REAL_TYPE_MAPPING} is enabled")
     }
+    if (params.legacyTrimCSVWrites) {
+      metricLogger.info(s"${Parameters.PARAM_LEGACY_TRIM_CSV_WRITES} is enabled")
+    }
     if (params.overrideNullable) {
       metricLogger.info(s"${Parameters.PARAM_OVERRIDE_NULLABLE} is enabled")
     }
-
   }
 
   val DEFAULT_APP_NAME = "spark-redshift-connector"

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/ParametersSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/ParametersSuite.scala
@@ -227,4 +227,17 @@ class ParametersSuite extends AnyFunSuite with Matchers {
       "be valid unicode identifier parts (char.isUnicodeIdentifierPart == true), " +
       "'!' character not allowed")
   }
+
+  test("tempdir_region allows pre-GA regions") {
+    val params = Map(
+      "tempdir" -> "s3://foo/bar",
+      "dbtable" -> "test_schema.test_table",
+      "url" -> "jdbc:redshift://foo/bar?user=user&password=password",
+      "forward_spark_s3_credentials" -> "true",
+      "tempdir_region" -> "pre-ga-region",
+    )
+    val mergedParams = Parameters.mergeParameters(params)
+
+    assert(mergedParams.tempDirRegion.get == "pre-ga-region")
+  }
 }

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/UtilsSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/UtilsSuite.scala
@@ -21,7 +21,7 @@ import java.net.URI
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration.Rule
-import io.github.spark_redshift_community.spark.redshift.Parameters.{MergedParameters, PARAM_LEGACY_JDBC_REAL_TYPE_MAPPING, PARAM_OVERRIDE_NULLABLE}
+import io.github.spark_redshift_community.spark.redshift.Parameters.{MergedParameters, PARAM_LEGACY_JDBC_REAL_TYPE_MAPPING, PARAM_LEGACY_TRIM_CSV_WRITES, PARAM_OVERRIDE_NULLABLE}
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
 import org.mockito.ArgumentMatchers.anyString
@@ -171,6 +171,7 @@ class UtilsSuite extends AnyFunSuite with Matchers with BeforeAndAfterAll {
  val fakeCredentials: Map[String, String] =
    Map[String, String]("forward_spark_s3_credentials" -> "true",
      Parameters.PARAM_LEGACY_JDBC_REAL_TYPE_MAPPING -> "false",
+     Parameters.PARAM_LEGACY_TRIM_CSV_WRITES -> "false",
      Parameters.PARAM_OVERRIDE_NULLABLE -> "false")
 
   test("collectMetrics logs buildinfo to INFO") {
@@ -190,6 +191,16 @@ class UtilsSuite extends AnyFunSuite with Matchers with BeforeAndAfterAll {
       verify(mockLogger).info(s"${Parameters.PARAM_LEGACY_JDBC_REAL_TYPE_MAPPING} is enabled")
   }
 
+  test("collectMetrics logs to INFO level when param LegacyTrimCSV is enabled") {
+    val mockLogger = mock[Logger]
+    val fakeCredentialsOverride = fakeCredentials +
+      (Parameters.PARAM_LEGACY_TRIM_CSV_WRITES -> "true")
+    val params = MergedParameters(fakeCredentialsOverride)
+
+    Utils.collectMetrics(params, Some(mockLogger))
+    verify(mockLogger).info(s"${Parameters.PARAM_LEGACY_TRIM_CSV_WRITES} is enabled")
+  }
+
   test("collectMetrics logs to INFO level when param OverrideNullable is enabled") {
     val mockLogger = mock[Logger]
     val fakeCredentialsOverride = fakeCredentials +
@@ -206,6 +217,14 @@ class UtilsSuite extends AnyFunSuite with Matchers with BeforeAndAfterAll {
 
     Utils.collectMetrics(params, Some(mockLogger))
     verify(mockLogger, never()).info(s"${Parameters.PARAM_LEGACY_JDBC_REAL_TYPE_MAPPING} is enabled")
+  }
+
+  test("collectMetrics does not log when param LegacyTrimCSV is disabled") {
+    val mockLogger = mock[Logger]
+    val params = MergedParameters(fakeCredentials)
+
+    Utils.collectMetrics(params, Some(mockLogger))
+    verify(mockLogger, never()).info(s"${Parameters.PARAM_LEGACY_TRIM_CSV_WRITES} is enabled")
   }
 
   test("collectMetrics does not log when param OverrideNullable is disabled") {

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/UtilsSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/UtilsSuite.scala
@@ -252,4 +252,12 @@ class UtilsSuite extends AnyFunSuite with Matchers with BeforeAndAfterAll {
 
     actualQueryGroup.contains(expectedString)
   }
+
+  test("pre-GA regions are permitted") {
+    val specifiedRegion = Utils.getDefaultTempDirRegion(Some("pre-ga-region"))
+    assert(specifiedRegion == "pre-ga-region")
+
+    val defaultRegion = Utils.getDefaultTempDirRegion(None)
+    assert(defaultRegion.isEmpty == false)
+  }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-ThisBuild / version := "6.1.0"
+ThisBuild / version := "6.2.0"


### PR DESCRIPTION
Adds the following improvements as described in the CHANGELOG:

- Validates support for Spark 3.3.4 and Spark 3.4.2
- Upgrades Redshift JDBC driver to version 2.1.0.24
- Fixes issue where CSV writes would trim leading and trailing whitespace on column values.
- Improves logging during Redshift writes to differentiate time spent writing to S3 versus COPYing into Redshift (#148)
- Supports pre-GA AWS regions.