### PR TITLE
Use SMALLINT if the Spark dataType is ShortType

### DIFF
--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
@@ -477,7 +477,7 @@ private[redshift] class JDBCWrapper extends Serializable {
       case java.sql.Types.NUMERIC       => DecimalType(38, 18) // Spark 1.5.0 default
       // Redshift Real is represented in 4 bytes IEEE Float. https://docs.aws.amazon.com/redshift/latest/dg/r_Numeric_types201.html
       case java.sql.Types.REAL          => if (params.exists(_.legacyJdbcRealTypeMapping)) { DoubleType } else { FloatType }
-      case java.sql.Types.SMALLINT      => IntegerType
+      case java.sql.Types.SMALLINT      => ShortType
       case java.sql.Types.TINYINT       => IntegerType
       case _                            => null
       // scalastyle:on

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftJDBCWrapper.scala
@@ -389,7 +389,7 @@ private[redshift] class JDBCWrapper extends Serializable {
           case LongType => "BIGINT"
           case DoubleType => "DOUBLE PRECISION"
           case FloatType => "REAL"
-          case ShortType => "INTEGER"
+          case ShortType => "SMALLINT"
           case ByteType => "SMALLINT" // Redshift does not support the BYTE type.
           case BooleanType => "BOOLEAN"
           case StringType =>


### PR DESCRIPTION
Now the connector creates Redshift table with `INTEGER` column if the DataFrame column is short. After this change, the connector creates `SMALLINT` column.

Note that this change will change the behavior if the DataFrame has ShortType column

The issue was opened long time ago https://github.com/databricks/spark-redshift/issues/401 but not fixed