### PR TITLE
[Feature] Support Automount RS

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,16 @@ for more information.</p>
     </td>
  </tr> 
  <tr>
+    <td><tt>addautomount</tt></td>
+    <td>No</td>
+    <td>false</td>
+    <td>
+        <p>
+        true - treat schema name as glue db name and append `awsdatacatalog` in rs dbtable name. more details : https://aws.amazon.com/blogs/big-data/simplify-external-object-access-in-amazon-redshift-using-automatic-mounting-of-the-aws-glue-data-catalog/
+        </p>
+    </td>
+ </tr> 
+ <tr>
     <td><tt>tempformat</tt></td>
     <td>No</td>
     <td><tt>AVRO</tt></td>

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/Parameters.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/Parameters.scala
@@ -204,7 +204,8 @@ private[redshift] object Parameters {
       if (dbtable.startsWith("(") && dbtable.endsWith(")")) {
         None
       } else {
-        Some(TableName.parseFromEscaped(dbtable))
+        val addAutoMount = parameters.getOrElse("addautomount", "").equals("true")
+        Some(TableName.parseFromEscaped(dbtable, addAutoMount))
       }
     }
 

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/TableName.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/TableName.scala
@@ -25,13 +25,20 @@ import scala.collection.mutable.ArrayBuffer
 /**
  * Wrapper class for representing the name of a Redshift table.
  */
-private[redshift] case class TableName(unescapedSchemaName: String, unescapedTableName: String) {
+private[redshift] case class TableName(
+    unescapedSchemaName: String,
+    unescapedTableName: String,
+    addAutomount: Boolean = false) {
   private def quote(str: String) = '"' + str.replace("\"", "\"\"") + '"'
+
+  private def automountPrefix = if (addAutomount) s"""${quote("awsdatacatalog")}.""" else ""
   def escapedSchemaName: String = quote(unescapedSchemaName)
   def escapedTableName: String = quote(unescapedTableName)
-  override def toString: String = s"$escapedSchemaName.$escapedTableName"
-  def toStatement: Identifier = Identifier(s"$escapedSchemaName.$escapedTableName")
-  def toConstantString: ConstantString = ConstantString(s"$escapedSchemaName.$escapedTableName")
+  override def toString: String = s"$automountPrefix$escapedSchemaName.$escapedTableName"
+  def toStatement: Identifier =
+    Identifier(s"$automountPrefix$escapedSchemaName.$escapedTableName")
+  def toConstantString: ConstantString =
+    ConstantString(s"$automountPrefix$escapedSchemaName.$escapedTableName")
 }
 
 private[redshift] object TableName {
@@ -39,14 +46,18 @@ private[redshift] object TableName {
    * Parses a table name which is assumed to have been escaped according to Redshift's rules for
    * delimited identifiers.
    */
-  def parseFromEscaped(str: String): TableName = {
+  def parseFromEscaped(str: String, addAutomount: Boolean = false): TableName = {
     def dropOuterQuotes(s: String) =
       if (s.startsWith("\"") && s.endsWith("\"")) s.drop(1).dropRight(1) else s
     def unescapeQuotes(s: String) = s.replace("\"\"", "\"")
     def unescape(s: String) = unescapeQuotes(dropOuterQuotes(s))
     splitByDots(str) match {
-      case Seq(tableName) => TableName("PUBLIC", unescape(tableName))
-      case Seq(schemaName, tableName) => TableName(unescape(schemaName), unescape(tableName))
+      case Seq(tableName) =>
+        TableName("PUBLIC", unescape(tableName), addAutomount)
+      case Seq(schemaName, tableName) =>
+        TableName(unescape(schemaName), unescape(tableName), addAutomount)
+      case Seq("awsdatacatalog", schemaName, tableName) =>
+        TableName(unescape(schemaName), unescape(tableName), addAutomount = true)
       case other => throw new IllegalArgumentException(s"Could not parse table name from '$str'")
     }
   }

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/ParametersSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/ParametersSuite.scala
@@ -53,6 +53,36 @@ class ParametersSuite extends AnyFunSuite with Matchers {
     }
   }
 
+  test("Minimal valid parameter map is accepted with awsdatacatalog") {
+    val params = Map(
+      "tempdir" -> "s3://foo/bar",
+      "dbtable" -> "test_schema.test_table",
+      "url" -> "jdbc:redshift://foo/bar?user=user&password=password",
+      "forward_spark_s3_credentials" -> "true",
+      "addautomount" -> "true",
+      "include_column_list" -> "true")
+
+    val mergedParams = Parameters.mergeParameters(params)
+
+    mergedParams.rootTempDir should startWith(params("tempdir"))
+    mergedParams.createPerQueryTempDir() should startWith(params("tempdir"))
+    mergedParams.jdbcUrl shouldBe params("url")
+    mergedParams.table shouldBe Some(
+      TableName("test_schema", "test_table", addAutomount = true))
+    assert(mergedParams.forwardSparkS3Credentials)
+    assert(mergedParams.includeColumnList)
+    assert(!mergedParams.legacyJdbcRealTypeMapping)
+
+    // Check that the defaults have been added
+    (
+      Parameters.DEFAULT_PARAMETERS
+        - "forward_spark_s3_credentials"
+        - "include_column_list"
+      ).foreach {
+      case (key, value) => mergedParams.parameters(key) shouldBe value
+    }
+  }
+
   test("createPerQueryTempDir() returns distinct temp paths") {
     val params = Map(
       "forward_spark_s3_credentials" -> "true",

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/RedshiftQuerySuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/RedshiftQuerySuite.scala
@@ -41,7 +41,7 @@ class RedshiftQuerySuite extends AnyFunSuite with BeforeAndAfterAll {
       create table student(id int)
        using io.github.spark_redshift_community.spark.redshift
        OPTIONS (
-      dbtable 'public.parquet_struct_table_view',
+      dbtable 'awsdatacatalog.public."parquet_struct_table_view"',
       tempdir '/tmp/dir',
       url '<jdbc-url-in-iam scheme>',
       forward_spark_s3_credentials 'true'
@@ -57,7 +57,7 @@ class RedshiftQuerySuite extends AnyFunSuite with BeforeAndAfterAll {
     assert(plan.isInstanceOf[RedshiftScanExec])
     val rsPlan = plan.asInstanceOf[RedshiftScanExec]
     assert(rsPlan.query.statementString ==
-      """SELECT * FROM "public"."parquet_struct_table_view" AS "RS_CONNECTOR_QUERY_ALIAS""""
+      """SELECT * FROM "awsdatacatalog"."public"."parquet_struct_table_view" AS "RS_CONNECTOR_QUERY_ALIAS""""
         .stripMargin)
   }
 

--- a/src/test/scala/io/github/spark_redshift_community/spark/redshift/TableNameSuite.scala
+++ b/src/test/scala/io/github/spark_redshift_community/spark/redshift/TableNameSuite.scala
@@ -22,6 +22,8 @@ import org.scalatest.funsuite.AnyFunSuite
 class TableNameSuite extends AnyFunSuite {
   test("TableName.parseFromEscaped") {
     assert(TableName.parseFromEscaped("foo.bar") === TableName("foo", "bar"))
+    assert(TableName.parseFromEscaped("foo.bar", addAutomount = true)
+        === TableName("foo", "bar", addAutomount = true))
     assert(TableName.parseFromEscaped("foo") === TableName("PUBLIC", "foo"))
     assert(TableName.parseFromEscaped("\"foo\"") === TableName("PUBLIC", "foo"))
     assert(TableName.parseFromEscaped("\"\"\"foo\"\"\".bar") === TableName("\"foo\"", "bar"))
@@ -34,5 +36,8 @@ class TableNameSuite extends AnyFunSuite {
     assert(TableName("foo", "bar").toString === """"foo"."bar"""")
     assert(TableName("PUBLIC", "bar").toString === """"PUBLIC"."bar"""")
     assert(TableName("\"foo\"", "bar").toString === "\"\"\"foo\"\"\".\"bar\"")
+    assert(
+      TableName("foo", "bar", addAutomount = true).toString ===
+        """"awsdatacatalog"."foo"."bar"""")
   }
 }


### PR DESCRIPTION
### About the change 

This adds support for automount feature of redshift which essentially treats the schema name as glue db name more details  : https://aws.amazon.com/blogs/big-data/simplify-external-object-access-in-amazon-redshift-using-automatic-mounting-of-the-aws-glue-data-catalog/