### PR TITLE
Allow Scala cross versions of 2.13.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ import java.util.Properties
 import java.io.FileInputStream
 
 val buildScalaVersion = sys.props.get("scala.buildVersion").getOrElse("2.12.15")
+crossScalaVersions := Seq(buildScalaVersion, "2.13.9")
 val sparkVersion = "3.5.0"
 val isCI = "true" equalsIgnoreCase System.getProperty("config.CI")
 

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/TableName.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/TableName.scala
@@ -89,6 +89,6 @@ private[redshift] object TableName {
     if (sb.nonEmpty) {
       parts.append(sb.toString())
     }
-    parts
+    parts.toSeq
   }
 }


### PR DESCRIPTION
Modify build.sbt to allow cross version compile
Fix code break.

It will fix the https://github.com/spark-redshift-community/spark-redshift/issues/112